### PR TITLE
ci/init

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+POSTGRES_USER=gitfed
+POSTGRES_PASSWORD=gitfed
+POSTGRES_DB=gitfed
+DATABASE_URL=postgres://gitfed:gitfed@psql:5432/gitfed?sslmode=disable
+REDIS_URL=redis://redis:6379

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.26.1-bookworm AS builder
+
+WORKDIR /build
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 go build -o /app ./cmd/main.go
+
+FROM gcr.io/distroless/static-debian12
+
+COPY --from=builder /app /app
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app", "/data/repos"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,27 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Lint') {
+            steps {
+                sh 'make lint'
+            }
+        }
+        stage('Test') {
+            steps {
+                sh 'make test'
+            }
+        }
+        stage('Build Image') {
+            steps {
+                sh 'make build-image'
+            }
+        }
+    }
+
+    post {
+        always {
+            sh 'make clean'
+        }
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,18 @@ build:
 clean:
 	@rm -f ./bin/main
 
-.PHONY: test build clean
+lint:
+	@go vet ./...
+
+build-image:
+	@docker build -t gitfed:latest .
+
+compose-up:
+	@docker compose up -d --build
+
+compose-down:
+	@docker compose down
+
+ci: lint test build-image
+
+.PHONY: test build clean lint build-image compose-up compose-down ci

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,39 @@
+services:
+  api:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - repos_data:/data/repos
+    env_file: .env
+    depends_on:
+      psql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  psql:
+    image: postgres:17-alpine
+    volumes:
+      - psql_data:/var/lib/postgresql/data
+    env_file: .env
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  repos_data:
+  psql_data:
+  redis_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
     image: redis:7-alpine
     volumes:
       - redis_data:/data
+    env_file: .env
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s

--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,10 @@
           gawk
 		  git
           gnugrep
+		  go
           gnumake
           jq
+          sqlc
           unzip
           zip
           docker-client


### PR DESCRIPTION
# Initialized CI/CD
-> Agnostic CI/CD tooling by using makefile considering this project in future going to be self-hosted
- Docker compose with Redis, PSQL and HTTP-API services
- Dockerfile with 2 stages: Build in golang:1.26.1-bookworm and prod in distroless image
- Makefile improved by adding flags used in CI/CD: Lint, build image and specifics docker flags
- Jenkinsfile added uses the make flags mentioned
- .env.example added for awareness of the flags needed 
- Nix improved: going to be standard for developers in repo 