### PR TITLE
Guard body in totp

### DIFF
--- a/internal/api/http/totp_presenter.go
+++ b/internal/api/http/totp_presenter.go
@@ -51,7 +51,7 @@ func (p *TOTPPresenter) Verify(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req totpVerifyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Code == "" {
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<10)).Decode(&req); err != nil || req.Code == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "code is required"})
 		return
 	}


### PR DESCRIPTION
## fix: limit request body size in TOTP verify endpoint

### Summary
Wraps `r.Body` with `http.MaxBytesReader` in `TOTPPresenter.Verify`, capping the request body at **1 KB** to prevent oversized payload attacks.

### Changes
- **`internal/api/http/totp_presenter.go`**: Replaced bare `r.Body` with `http.MaxBytesReader(w, r.Body, 1<<10)` before JSON decoding. Malformed or oversized requests return `400 Bad Request`.

### Motivation
The previous implementation had no body size limit, leaving the endpoint open to memory exhaustion via large payloads. Legitimate TOTP codes are well within 1 KB, so there is no impact on normal usage.