### PR TITLE
fix(config): validate rate limit env on load

### DIFF
--- a/cmd/http-api/main.go
+++ b/cmd/http-api/main.go
@@ -29,7 +29,11 @@ func main() {
 		fmt.Fprintf(os.Stderr, "usage: set REPOS_DIR or pass <repos-dir> as argument\n")
 		os.Exit(1)
 	}
-	cfg := config.Load()
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load config: %v\n", err)
+		os.Exit(1)
+	}
 
 	log := logger.New(cfg.Log)
 	logger.SetDefault(log)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/qoppa-tech/toy-gitfed/internal/database"
 	"github.com/qoppa-tech/toy-gitfed/internal/modules/sso"
 	"github.com/qoppa-tech/toy-gitfed/internal/store"
@@ -35,8 +37,8 @@ type Config struct {
 	SecureCookies bool
 }
 
-func Load() Config {
-	return Config{
+func Load() (Config, error) {
+	cfg := Config{
 		Database: database.Config{
 			Host:     env.Or("DB_HOST", "localhost"),
 			Port:     env.Int("DB_PORT", 5432),
@@ -76,4 +78,13 @@ func Load() Config {
 		TOTPIssuer:    env.Or("TOTP_ISSUER", "gitfed"),
 		SecureCookies: env.Bool("SECURE_COOKIES", false),
 	}
+
+	if cfg.RateLimit.IPRate <= 0 || cfg.RateLimit.IPBurst <= 0 {
+		return Config{}, fmt.Errorf("invalid IP rate limit config: rate=%d burst=%d", cfg.RateLimit.IPRate, cfg.RateLimit.IPBurst)
+	}
+	if cfg.RateLimit.UserRate <= 0 || cfg.RateLimit.UserBurst <= 0 {
+		return Config{}, fmt.Errorf("invalid user rate limit config: rate=%d burst=%d", cfg.RateLimit.UserRate, cfg.RateLimit.UserBurst)
+	}
+
+	return cfg, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,63 @@
+package config
+
+import "testing"
+
+func TestLoadRejectsInvalidIPRateLimit(t *testing.T) {
+	t.Setenv("RATE_LIMIT_IP_RATE", "0")
+	t.Setenv("RATE_LIMIT_IP_BURST", "20")
+	t.Setenv("RATE_LIMIT_USER_RATE", "200")
+	t.Setenv("RATE_LIMIT_USER_BURST", "40")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for invalid IP rate config")
+	}
+}
+
+func TestLoadRejectsInvalidIPBurst(t *testing.T) {
+	t.Setenv("RATE_LIMIT_IP_RATE", "100")
+	t.Setenv("RATE_LIMIT_IP_BURST", "-1")
+	t.Setenv("RATE_LIMIT_USER_RATE", "200")
+	t.Setenv("RATE_LIMIT_USER_BURST", "40")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for invalid IP burst config")
+	}
+}
+
+func TestLoadRejectsInvalidUserRateLimit(t *testing.T) {
+	t.Setenv("RATE_LIMIT_IP_RATE", "100")
+	t.Setenv("RATE_LIMIT_IP_BURST", "20")
+	t.Setenv("RATE_LIMIT_USER_RATE", "0")
+	t.Setenv("RATE_LIMIT_USER_BURST", "40")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for invalid user rate config")
+	}
+}
+
+func TestLoadRejectsInvalidUserBurst(t *testing.T) {
+	t.Setenv("RATE_LIMIT_IP_RATE", "100")
+	t.Setenv("RATE_LIMIT_IP_BURST", "20")
+	t.Setenv("RATE_LIMIT_USER_RATE", "200")
+	t.Setenv("RATE_LIMIT_USER_BURST", "0")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for invalid user burst config")
+	}
+}
+
+func TestLoadAllowsValidRateLimits(t *testing.T) {
+	t.Setenv("RATE_LIMIT_IP_RATE", "100")
+	t.Setenv("RATE_LIMIT_IP_BURST", "20")
+	t.Setenv("RATE_LIMIT_USER_RATE", "200")
+	t.Setenv("RATE_LIMIT_USER_BURST", "40")
+
+	_, err := Load()
+	if err != nil {
+		t.Fatalf("expected valid config, got error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Validate `RATE_LIMIT_IP_RATE`, `RATE_LIMIT_IP_BURST`, `RATE_LIMIT_USER_RATE`, and `RATE_LIMIT_USER_BURST` in `config.Load()` and return error when value is `<= 0`.
- Update HTTP API bootstrap to handle config load errors and exit early with clear message.
- Add config tests covering invalid zero/negative values and valid happy path.

## Testing
- `go test ./...`

Closes #12